### PR TITLE
Use proxies for CLI OrderSendCommand

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -48,6 +48,13 @@
             </argument>
         </arguments>
     </type>
+    <type name="Paazl\CheckoutWidget\Console\Command\OrderSendCommand">
+        <arguments>
+            <argument name="orderRepository" xsi:type="object">Magento\Sales\Api\OrderRepositoryInterface\Proxy</argument>
+            <argument name="sendToService" xsi:type="object">Paazl\CheckoutWidget\Model\Api\Processor\SendToService\Proxy</argument>
+            <argument name="state" xsi:type="object">Magento\Framework\App\State\Proxy</argument>
+        </arguments>
+    </type>
 
     <type name="Magento\Framework\View\Asset\Minification">
         <plugin name="paazl-minification-plugin" type="Paazl\CheckoutWidget\Plugin\ExcludeFromMinification"/>


### PR DESCRIPTION
This prevents the following error being thrown when running integration tests:

In WebsiteRepository.php line 159:
The default website isn't defined. Set the website and try again.