### PR TITLE
Check if order shipping method is not null

### DIFF
--- a/Plugin/Sales/OrderRepositoryPlugin.php
+++ b/Plugin/Sales/OrderRepositoryPlugin.php
@@ -93,6 +93,11 @@ class OrderRepositoryPlugin
         OrderInterface $order
     ) {
         $shippingMethod = $order->getShippingMethod(true);
+
+        if (!$shippingMethod) {
+            return $order;
+        }
+
         $carrierCode = $shippingMethod->getData('carrier_code');
 
         if ($carrierCode !== Paazlshipping::CODE) {


### PR DESCRIPTION
Fixes the following error:
Uncaught Error: Call to a member function getData() on null